### PR TITLE
Fix: cannot send HTTPS notification message from Mobius

### DIFF
--- a/mobius/sgn_man.js
+++ b/mobius/sgn_man.js
@@ -206,7 +206,7 @@ function request_noti_http(nu, ri, bodyString, bodytype, xm2mri) {
         });
     }
     else {
-        options.ca = fs.readFileSync('ca-crt.pem');
+        process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
 
         req = https.request(options, function (res) {
             response_noti_http(res);

--- a/mobius/sgn_man.js
+++ b/mobius/sgn_man.js
@@ -206,8 +206,7 @@ function request_noti_http(nu, ri, bodyString, bodytype, xm2mri) {
         });
     }
     else {
-        process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
-
+        options.rejectUnauthorized = false;
         req = https.request(options, function (res) {
             response_noti_http(res);
         });


### PR DESCRIPTION
Fixed the issue that Mobius cannot send HTTPS notification messages.