### PR TITLE
Fix: TypeError: path.replace is not a function

### DIFF
--- a/app.js
+++ b/app.js
@@ -1790,7 +1790,7 @@ app.use((req, res, next) => {
 // }));
 
 // remoteCSE, ae, cnt
-app.post(onem2mParser, (request, response) => {
+app.post('*', onem2mParser, (request, response) => {
     var fullBody = '';
     request.on('data', (chunk) => {
         fullBody += chunk.toString();
@@ -2078,7 +2078,7 @@ app.post(onem2mParser, (request, response) => {
     });
 });
 
-app.get(onem2mParser, (request, response) => {
+app.get('*', onem2mParser, (request, response) => {
     var fullBody = '';
     request.on('data', (chunk) => {
         fullBody += chunk.toString();
@@ -2260,7 +2260,7 @@ app.get(onem2mParser, (request, response) => {
 });
 
 
-app.put(onem2mParser, (request, response) => {
+app.put('*', onem2mParser, (request, response) => {
     var fullBody = '';
     request.on('data', (chunk) => {
         fullBody += chunk.toString();
@@ -2474,7 +2474,7 @@ app.put(onem2mParser, (request, response) => {
     });
 });
 
-app.delete(onem2mParser, (request, response) => {
+app.delete('*', onem2mParser, (request, response) => {
     var fullBody = '';
     request.on('data', (chunk) => {
         fullBody += chunk.toString();


### PR DESCRIPTION
Resolves "TypeError: path.replace is not a function" caused by the express 4.7 and above